### PR TITLE
feat: add the zig toolchain to the development container

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -13,14 +13,17 @@
 #   ./autogen.sh && ./configure && make
 #
 # Build args:
-#   UBUNTU_TAG   base image (default latest, i.e. the current Ubuntu LTS);
+#   UBUNTU_TAG   base image (default 26.04, i.e. the current Ubuntu LTS);
 #                pin with e.g. --build-arg UBUNTU_TAG=24.04
+#   ZIG_VERSION  zig release to install from ziglang.org/download (default
+#                0.16.0); pin with e.g. --build-arg ZIG_VERSION=0.15.1
 #
 # For now the image targets a successful build only. The test-suite host
 # languages (go, java, ruby, ...) and the manual toolchain (asciidoc,
 # pygmentize) can be layered on later.
 
-ARG UBUNTU_TAG=latest
+ARG UBUNTU_TAG=26.04
+ARG ZIG_VERSION=0.16.0
 
 # No platform pin: unlike ragel 6.x, mainline builds natively on both amd64
 # and arm64.
@@ -29,5 +32,30 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        build-essential autoconf automake libtool git ca-certificates; \
+        build-essential autoconf automake libtool git ca-certificates \
+        curl xz-utils; \
     rm -rf /var/lib/apt/lists/*
+
+# Zig, from the upstream binary tarballs. Not needed to build the tree; it is
+# here as a host language toolchain (and as a drop-in C/C++ cross compiler via
+# "zig cc"). Shasums are those published in ziglang.org/download/index.json for
+# ZIG_VERSION, so bumping the version means bumping these too.
+ARG ZIG_VERSION
+ARG ZIG_SHA256_X86_64=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
+ARG ZIG_SHA256_AARCH64=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  sha="$ZIG_SHA256_X86_64" ;; \
+        aarch64) sha="$ZIG_SHA256_AARCH64" ;; \
+        *) echo "no zig binary release for $arch" >&2; exit 1 ;; \
+    esac; \
+    tarball="zig-$arch-linux-$ZIG_VERSION.tar.xz"; \
+    curl -fsSL -o "/tmp/$tarball" \
+        "https://ziglang.org/download/$ZIG_VERSION/$tarball"; \
+    echo "$sha  /tmp/$tarball" | sha256sum -c -; \
+    mkdir -p /opt/zig; \
+    tar -xJf "/tmp/$tarball" -C /opt/zig --strip-components=1; \
+    rm -f "/tmp/$tarball"; \
+    ln -s /opt/zig/zig /usr/local/bin/zig; \
+    zig version

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -29,6 +29,14 @@ ARG ZIG_VERSION=0.16.0
 # and arm64.
 FROM ubuntu:${UBUNTU_TAG} AS dev
 ENV DEBIAN_FRONTEND=noninteractive
+
+# By default the container will run in the C locale. Some ragel contributions
+# are in other charsets so ensure those display correctly when working in
+# containers built with this dockerfile. C.UTF-8 is built into glibc, so no
+# locales package is needed. LANG only: leave LC_ALL unset so the user can
+# still override individual categories.
+ENV LANG=C.UTF-8
+
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \

--- a/test/ragel.d/trans-zig.lm
+++ b/test/ragel.d/trans-zig.lm
@@ -188,6 +188,11 @@ int print_stmt( Stmt: indep::print_stmt )
 		send Out
 			"_out( \"{s}\", .{ data\[@intCast(ts)..@intCast(te)\] } );
 	}
+	case [`print_off `;]
+	{
+		send Out
+			"_out( \"{d}\", .{ p } );
+	}
 }
 
 void buf_stmt( BufStmt: indep::buf_stmt )


### PR DESCRIPTION
Now that #215 has landed, the zig test cases need a zig compiler and the
development image had none. This installs one, along with two smaller fixes
that came out of using the image.

## Zig

Installed from the upstream binary tarballs rather than from apt, so a
specific release can be pinned. The `RUN` step selects the x86_64 or aarch64
tarball from `uname -m` and checks it against the shasum published in
`ziglang.org/download/index.json`, so a corrupt or substituted download fails
the build instead of producing a quietly broken image.

`ZIG_VERSION` is a build arg, defaulting to 0.16.0:

```
docker build -t colm-suite-dev --build-arg ZIG_VERSION=0.15.1 package/
```

The shasums are per-version, so bumping the version means bumping them too —
the comment above them says as much.

Zig is not needed to build the tree. It is here as a host language toolchain
for the test suite, and it doubles as a drop-in C/C++ cross compiler via
`zig cc`. `curl` and `xz-utils` are added because the download step needs them.

## Pin UBUNTU_TAG to 26.04

The base was `ubuntu:latest`, which moves under the image. 26.04 is what
`latest` resolves to today, so this is not a content change now, but it keeps
the image reproducible when the next LTS ships. `--build-arg UBUNTU_TAG=24.04`
still works.

## LANG=C.UTF-8

The container otherwise runs in the C locale, whose charset is ASCII, so
non-ASCII text is rendered as escapes rather than displayed. Some ragel
contributions are in other charsets. C.UTF-8 is built into glibc on the base
image, so no `locales` package is needed. `LANG` only — `LC_ALL` is left unset
so individual categories can still be overridden.

## Translate print_off in the zig test spec

`test/ragel.d/trans-zig.lm` handled every `indep` statement except
`print_off`. Five cases use it — `eofcall1`, `eofcall2`, `eofgoto1`,
`eofgoto2`, `eofret1` — and each carries:

```
* @PROHIBIT_LANGUAGES: cv ruby ocaml rust crack
```

which names exactly the trans specs that lack `print_off`
(`trans-crack.lm`, `trans-ocaml.lm`, `trans-ruby.lm`, `trans-rust.lm`). Zig is
not on that list, so those cases were already being generated for zig with no
translation for the statement.

The fix prints `p` directly:

```
	case [`print_off `;]
	{
		send Out
			"_out( \"{d}\", .{ p } );
	}
```

In zig, as in go, java, csharp and julia, `p` is an index rather than a
pointer, so there is no base to subtract. The C and D specs compute `p - data`
because theirs is a pointer.

## Test

Built the tree with zig 0.16.0 on the PATH and ran the full `test/ragel.d`
suite. Every zig case passes — 0 mismatches across all zig case/backend
combinations, including the 60 that the `print_off` change covers
(5 cases x 12 backends).

The suite also reports 100 failures in `genrep1`, `genrep2`, `genrep5`,
`genrep6`, `genrep7`, `genrep8`, `nfa3` and `tsreset`, all in their non-zig
forms. This branch touches only `package/Dockerfile` and
`test/ragel.d/trans-zig.lm`, neither of which those cases go through, so they
are not from these commits. Worth a separate look — note that `make check`
does not surface them, because `test/ragel.d` declares `TESTS = gentests`,
which generates the cases without running them.
