### PR TITLE
Allow installing colm and ragel separately

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,19 @@ cmake --build build -j$(nproc)
 cmake --install build
 ```
 
+Colm and ragel install together by default. Either half can be installed on its
+own; the whole tree is built either way.
+
+```bash
+# autotools
+./configure --disable-install-colm     # ragel only
+./configure --disable-install-ragel    # colm only
+
+# cmake
+cmake -S . -B build -DCOLM_INSTALL_COLM=OFF
+cmake -S . -B build -DCOLM_INSTALL_RAGEL=OFF
+```
+
 ## Development Commands
 
 ```bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,37 @@ message(STATUS "colm ${COLM_VERSION} (${COLM_PUBDATE}), "
 option(COLM_MAKE_INSTALL
 	"Generate install rules for the colm suite" ON)
 
+#
+# Which halves of the suite to install. The build always covers the whole tree:
+# ragel's parsers are written in colm, so colm is built either way. These
+# select what the install step copies out.
+#
+# The colm runtime library and the aapl headers go out in both cases. Ragel
+# links libcolm and the installed libfsm headers include aapl, so neither can
+# be left out of a ragel-only install.
+#
+option(COLM_INSTALL_COLM
+	"Install the colm program and its development files" ON)
+
+option(COLM_INSTALL_RAGEL
+	"Install ragel, its host backends, libragel, libfsm and cgil" ON)
+
+if(COLM_MAKE_INSTALL AND NOT COLM_INSTALL_COLM AND NOT COLM_INSTALL_RAGEL)
+	message(FATAL_ERROR
+		"COLM_INSTALL_COLM and COLM_INSTALL_RAGEL cannot both be off. "
+		"Use -DCOLM_MAKE_INSTALL=OFF to drop the install rules entirely.")
+endif()
+
+#
+# Fold COLM_MAKE_INSTALL into the two selectors so that each install block
+# below only has one variable to test. These shadow the cache entries of the
+# same name for this directory and everything under it.
+#
+if(NOT COLM_MAKE_INSTALL)
+	set(COLM_INSTALL_COLM OFF)
+	set(COLM_INSTALL_RAGEL OFF)
+endif()
+
 option(COLM_BUILD_EXAMPLES
 	"Build the ragel examples" OFF)
 
@@ -144,8 +175,13 @@ if(COLM_BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
 
-if(COLM_MAKE_INSTALL)
-	# dist_doc_DATA in Makefile.am
-	install(FILES colm.vim ragel.vim
+# dist_doc_DATA in Makefile.am
+if(COLM_INSTALL_COLM)
+	install(FILES colm.vim
+		DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+endif()
+
+if(COLM_INSTALL_RAGEL)
+	install(FILES ragel.vim
 		DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 endif()

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,16 @@
 
 SUBDIRS = src doc test
 
-dist_doc_DATA = colm.vim ragel.vim
+dist_doc_DATA =
+
+if INSTALL_COLM
+dist_doc_DATA += colm.vim
+endif
+
+if INSTALL_RAGEL
+dist_doc_DATA += ragel.vim
+endif
+
 EXTRA_DIST = colm.vim ragel.vim sedsubst CMakeLists.txt
 ACLOCAL_AMFLAGS = -I m4
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ $ make
 $ make install
 ```
 
+### Installing one half of the suite
+
+Colm and ragel install together by default. The two halves can be installed
+separately, which is useful for a ragel user who has no interest in colm, or a
+colm user who has no interest in ragel:
+
+```
+$ ./configure --disable-install-colm    # ragel only
+$ ./configure --disable-install-ragel   # colm only
+```
+
+The whole tree is still built either way. Ragel's parsers are written in colm,
+so colm has to be built before ragel can be, and building everything keeps the
+test suite runnable from the build tree. Only the install step is narrowed.
+
+Two things go out in both cases and cannot be excluded from a ragel-only
+install: the colm runtime library, which the ragel programs link, and the aapl
+headers, which the installed libfsm headers include.
+
 ### Building with CMake
 
 CMake (3.16 or later) is supported as an alternative to autotools. It builds the
@@ -180,9 +199,15 @@ Options:
 | Option | Default | Meaning |
 | --- | --- | --- |
 | `COLM_MAKE_INSTALL` | `ON` | Generate install rules. |
+| `COLM_INSTALL_COLM` | `ON` | Install the colm program and its development files. |
+| `COLM_INSTALL_RAGEL` | `ON` | Install ragel, its host backends, libragel, libfsm and cgil. |
 | `COLM_BUILD_EXAMPLES` | `OFF` | Build the ragel examples under `examples/`. |
 | `BUILD_STANDALONE` | `ON` on Windows | Link the executables statically. |
 | `BUILD_SHARED_LIBS` | `OFF` | Build libcolm, libfsm and libragel as shared libraries. |
+
+`COLM_INSTALL_COLM` and `COLM_INSTALL_RAGEL` are the cmake spelling of
+`--disable-install-colm` and `--disable-install-ragel`; see [Installing one half
+of the suite](#installing-one-half-of-the-suite) for what each one covers.
 
 All executables are written to `build/bin`, which is where the `ragel` driver
 expects to find the per-host-language backends (`ragel-c`, `ragel-go`, ...).

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,34 @@ AC_ARG_ENABLE(program,
 AM_CONDITIONAL([BUILD_PROGRAM],    [test "x$build_program" = "xyes"])
 AM_CONDITIONAL([WITH_RAGEL_KELBT], [test "x$RAGEL_KELBT" = "xyes"])
 
+dnl
+dnl Which halves of the suite to install. The build always covers the whole
+dnl tree: ragel's parsers are written in colm, so colm must be built either
+dnl way. These options control only what "make install" copies out.
+dnl
+dnl The colm runtime library and the aapl headers are installed in both cases.
+dnl Ragel links libcolm and the installed libfsm headers include aapl, so
+dnl neither can be left out of a ragel-only install.
+dnl
+AC_ARG_ENABLE(install-colm,
+	[AS_HELP_STRING([--disable-install-colm],[do not install the colm program and headers])],
+	[install_colm=$enableval],
+	[install_colm=yes]
+)
+
+AC_ARG_ENABLE(install-ragel,
+	[AS_HELP_STRING([--disable-install-ragel],[do not install ragel, libragel, libfsm or cgil])],
+	[install_ragel=$enableval],
+	[install_ragel=yes]
+)
+
+if test "x$install_colm" != "xyes" && test "x$install_ragel" != "xyes"; then
+	AC_MSG_ERROR([nothing left to install: give at most one of --disable-install-colm and --disable-install-ragel])
+fi
+
+AM_CONDITIONAL([INSTALL_COLM],  [test "x$install_colm"  = "xyes"])
+AM_CONDITIONAL([INSTALL_RAGEL], [test "x$install_ragel" = "xyes"])
+
 dnl This is from ragel, but already have one above from colm. Need to merge.
 dnl AM_CONDITIONAL([BUILD_MANUAL],     [test "x$build_manual" = "xyes"])
 

--- a/doc/colm/Makefile.am
+++ b/doc/colm/Makefile.am
@@ -45,7 +45,9 @@ EXTRA_DIST = $(IN_FILES) $(CODE)
 
 if BUILD_MANUAL
 
+if INSTALL_COLM
 doc_DATA = $(OUT_FILES)
+endif
 
 SUFFIXES = .html .adoc
 

--- a/doc/ragel/Makefile.am
+++ b/doc/ragel/Makefile.am
@@ -20,7 +20,9 @@
 # SOFTWARE.
 #
 
-man_MANS = ragel.1 
+if INSTALL_RAGEL
+man_MANS = ragel.1
+endif
 
 EXTRA_DIST = ragel-guide.txt ragel.1.in \
 	bmconcat.fig bmregex.fig dropdown.fig exdoneact.fig \
@@ -37,7 +39,9 @@ ragel.1: ragel.1.in
 
 if BUILD_MANUAL
 
+if INSTALL_RAGEL
 doc_DATA = ragel-guide.html ragel-guide.pdf
+endif
 
 .fig.png:
 	fig2dev -L png -S 4 $< $@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,7 +209,7 @@ add_subdirectory(ragel)
 #
 # Install.
 #
-if(COLM_MAKE_INSTALL)
+if(COLM_INSTALL_COLM OR COLM_INSTALL_RAGEL)
 	set(_PACKAGE_NAME colm)
 
 	if(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
@@ -221,14 +221,25 @@ if(COLM_MAKE_INSTALL)
 	configure_file(colm-config.cmake.in
 		"${PROJECT_BINARY_DIR}/${_PACKAGE_NAME}-config.cmake" @ONLY)
 
-	install(FILES ${COLM_INSTALL_HDR}
-		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/colm")
-
-	install(TARGETS libcolm colm
+	#
+	# The runtime library goes out even when only ragel is being installed.
+	# The ragel programs link it, and the exported ragel targets name
+	# colm::libcolm, so the colm package has to be resolvable.
+	#
+	install(TARGETS libcolm
 		EXPORT ${_PACKAGE_NAME}-targets
 		RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 		LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 		ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+	if(COLM_INSTALL_COLM)
+		install(TARGETS colm
+			EXPORT ${_PACKAGE_NAME}-targets
+			RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+		install(FILES ${COLM_INSTALL_HDR}
+			DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/colm")
+	endif()
 
 	install(EXPORT ${_PACKAGE_NAME}-targets
 		NAMESPACE ${_PACKAGE_NAME}::
@@ -249,7 +260,8 @@ if(COLM_MAKE_INSTALL)
 		"${PROJECT_BINARY_DIR}/${_PACKAGE_NAME}-config-version.cmake"
 		DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
 
-	# aapl is a header-only template library.
+	# aapl is a header-only template library. The installed libfsm headers
+	# include it, so it goes out with either half of the suite.
 	install(DIRECTORY aapl/
 		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aapl"
 		FILES_MATCHING PATTERN "*.h")

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,8 +26,20 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/aapl
 
 AUTOMAKE_OPTIONS = subdir-objects
 
+#
+# The colm program itself is always built: ragel's parsers are written in colm.
+# Whether it is installed is a separate question, controlled by
+# --disable-install-colm.
+#
+noinst_PROGRAMS =
+
+if INSTALL_COLM
 bin_PROGRAMS = colm
 bin_SCRIPTS = colm-wrap
+else
+noinst_PROGRAMS += colm
+noinst_SCRIPTS = colm-wrap
+endif
 
 RUNTIME_SRC = \
 	map.c pdarun.c list.c input.c stream.c debug.c \
@@ -75,7 +87,11 @@ libprog_a_CXXFLAGS = $(common_CFLAGS)
 
 colmincdir = $(includedir)/colm
 
+if INSTALL_COLM
 colminc_HEADERS = $(RUNTIME_HDR)
+else
+noinst_HEADERS = $(RUNTIME_HDR)
+endif
 
 if EXTERNAL_COLM
 
@@ -89,7 +105,7 @@ AM_LDFLAGS = $(EXTERNAL_LIBS)
 
 else
 
-noinst_PROGRAMS = bootstrap0 bootstrap1 bootstrap2
+noinst_PROGRAMS += bootstrap0 bootstrap1 bootstrap2
 
 BUILD_PARSE_3_WITH = $(builddir)/bootstrap2$(EXEEXT)
 WRAP_PARSE_3_WITH = $(builddir)/colm-wrap

--- a/src/cgil/CMakeLists.txt
+++ b/src/cgil/CMakeLists.txt
@@ -43,7 +43,7 @@ endforeach()
 
 add_custom_target(cgil ALL DEPENDS ${_cgil_programs})
 
-if(COLM_MAKE_INSTALL)
+if(COLM_INSTALL_RAGEL)
 	set(_cgil_data)
 	foreach(_f ${CGIL_FILES})
 		list(APPEND _cgil_data "${CMAKE_CURRENT_LIST_DIR}/${_f}")

--- a/src/cgil/Makefile.am
+++ b/src/cgil/Makefile.am
@@ -1,11 +1,15 @@
 SUBDIRS = test
 
-pkgdata_DATA = $(CGIL_FILES)
-
 CGIL_FILES = ril.lm rlhc-main.lm \
 	rlhc-c.lm rlhc-csharp.lm rlhc-go.lm rlhc-js.lm rlhc-ruby.lm \
 	rlhc-crack.lm rlhc-d.lm rlhc-java.lm rlhc-julia.lm rlhc-ocaml.lm rlhc-rust.lm \
 	rlhc-zig.lm
 
-EXTRA_DIST = $(CGIL_FILES) CMakeLists.txt
+# The cgil sources translate ril, the intermediate code generation language
+# emitted by libfsm, into the host languages. They are used only by ragel, so
+# they go with it.
+if INSTALL_RAGEL
+pkgdata_DATA = $(CGIL_FILES)
+endif
 
+EXTRA_DIST = $(CGIL_FILES) CMakeLists.txt

--- a/src/cgil/test/Makefile.am
+++ b/src/cgil/test/Makefile.am
@@ -1,7 +1,16 @@
+# The cgil translators belong to the ragel half of the suite. They are built
+# either way so the test suite here can run from the build tree.
+if INSTALL_RAGEL
 bin_PROGRAMS = \
 	cgil-c cgil-crack cgil-csharp cgil-d \
 	cgil-go cgil-java cgil-js cgil-julia \
 	cgil-ocaml cgil-ruby cgil-rust cgil-zig
+else
+noinst_PROGRAMS = \
+	cgil-c cgil-crack cgil-csharp cgil-d \
+	cgil-go cgil-java cgil-js cgil-julia \
+	cgil-ocaml cgil-ruby cgil-rust cgil-zig
+endif
 
 check_SCRIPTS = subject.mk subject.sh runtests
 

--- a/src/libfsm/CMakeLists.txt
+++ b/src/libfsm/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(libfsm PROPERTIES
 
 add_library(ragel::libfsm ALIAS libfsm)
 
-if(COLM_MAKE_INSTALL)
+if(COLM_INSTALL_RAGEL)
 	set(_libfsm_install_hdr)
 	foreach(_hdr ${LIBFSM_HDR})
 		list(APPEND _libfsm_install_hdr "${CMAKE_CURRENT_LIST_DIR}/${_hdr}")

--- a/src/libfsm/Makefile.am
+++ b/src/libfsm/Makefile.am
@@ -2,6 +2,12 @@
 # generators for C, asm and cgil (Code Gen Intermediate Language) . It is
 # useful for building state machine code generators in programs not connected
 # to the ragel language.
+#
+# libfsm is part of the ragel half of the suite. When it is not being
+# installed it is still built, as a convenience library, so the ragel
+# programs can be built and tested from the build tree.
+#
+if INSTALL_RAGEL
 lib_LTLIBRARIES = libfsm.la
 
 libfsminclude_HEADERS = \
@@ -15,6 +21,9 @@ libfsminclude_HEADERS = \
 	tables.h \
 	actloop.h actexp.h \
 	ipgoto.h
+else
+noinst_LTLIBRARIES = libfsm.la
+endif
 
 # nodist_pkginclude_HEADERS = config.h
 
@@ -35,10 +44,12 @@ dist_libfsm_la_SOURCES = \
 	goto.cc gotoloop.cc gotoexp.cc ipgoto.cc \
 	dot.cc asm.cc
 
+if INSTALL_RAGEL
 libfsm_la_LDFLAGS = -release $(VERSION) -no-undefined
 
 if LINKER_NO_UNDEFINED
 libfsm_la_LDFLAGS += -Wl,--no-undefined
+endif
 endif
 
 EXTRA_DIST = CMakeLists.txt

--- a/src/ragel/CMakeLists.txt
+++ b/src/ragel/CMakeLists.txt
@@ -119,7 +119,7 @@ function(ragel_host name backend rlhc lm)
 
 	target_link_libraries(${name} PRIVATE libragel libfsm)
 
-	if(COLM_MAKE_INSTALL)
+	if(COLM_INSTALL_RAGEL)
 		install(TARGETS ${name}
 			EXPORT ${_PACKAGE_NAME}-targets
 			RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
@@ -132,7 +132,7 @@ foreach(_subdir host-asm host-c host-crack host-csharp host-d host-go
 	add_subdirectory(${_subdir})
 endforeach()
 
-if(COLM_MAKE_INSTALL)
+if(COLM_INSTALL_RAGEL)
 	if(NOT DEFINED CMAKE_INSTALL_CMAKEDIR_RAGEL)
 		set(CMAKE_INSTALL_CMAKEDIR_RAGEL
 			"${CMAKE_INSTALL_LIBDIR}/cmake/${_PACKAGE_NAME}"

--- a/src/ragel/Makefile.am
+++ b/src/ragel/Makefile.am
@@ -2,15 +2,22 @@ SUBDIRS = . host-ruby host-asm host-julia host-ocaml host-c \
 	host-d host-csharp host-go host-java host-rust host-crack host-js \
 	host-zig
 
-# libragel contains the parse tree and other parsing support code. Everything
-# except the reducers, which are specific to the frontends.
-lib_LTLIBRARIES = libragel.la
-
-bin_PROGRAMS = ragel
-
 # nodist_pkginclude_HEADERS = config.h
 
+# libragel contains the parse tree and other parsing support code. Everything
+# except the reducers, which are specific to the frontends.
+#
+# This is the ragel half of the suite. With --disable-install-ragel it is all
+# still built, so it can be tested from the build tree, but none of it is
+# installed.
+if INSTALL_RAGEL
+lib_LTLIBRARIES = libragel.la
+bin_PROGRAMS = ragel
 data_DATA = ragel.lm
+else
+noinst_LTLIBRARIES = libragel.la
+noinst_PROGRAMS = ragel
+endif
 
 #
 # libragel: ragel program minus host-specific code
@@ -23,11 +30,14 @@ dist_libragel_la_SOURCES = \
 	parsetree.cc longest.cc parsedata.cc inputdata.cc load.cc reducer.cc \
 	ncommon.cc allocgen.cc
 
-libragel_la_LDFLAGS = -no-undefined
 libragel_la_LIBADD = $(LIBFSM_LA) $(LIBCOLM_LA)
+
+if INSTALL_RAGEL
+libragel_la_LDFLAGS = -no-undefined
 
 if LINKER_NO_UNDEFINED
 libragel_la_LDFLAGS += -Wl,--no-undefined
+endif
 endif
 
 #

--- a/src/ragel/host-asm/Makefile.am
+++ b/src/ragel/host-asm/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-asm
+else
+noinst_PROGRAMS = ragel-asm
+endif
 
 ragel_asm_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-c/Makefile.am
+++ b/src/ragel/host-c/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-c
+else
+noinst_PROGRAMS = ragel-c
+endif
 
 ragel_c_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-crack/Makefile.am
+++ b/src/ragel/host-crack/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-crack
+else
+noinst_PROGRAMS = ragel-crack
+endif
 
 ragel_crack_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-csharp/Makefile.am
+++ b/src/ragel/host-csharp/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-csharp
+else
+noinst_PROGRAMS = ragel-csharp
+endif
 
 ragel_csharp_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-d/Makefile.am
+++ b/src/ragel/host-d/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-d
+else
+noinst_PROGRAMS = ragel-d
+endif
 
 ragel_d_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-go/CMakeLists.txt
+++ b/src/ragel/host-go/CMakeLists.txt
@@ -1,6 +1,6 @@
 ragel_host(ragel-go rlparseGo "rlhcGo" "rlhc-go.lm")
 
-if(COLM_MAKE_INSTALL)
+if(COLM_INSTALL_RAGEL)
 	install(FILES out-go.lm
 		DESTINATION "${CMAKE_INSTALL_DATADIR}")
 endif()

--- a/src/ragel/host-go/Makefile.am
+++ b/src/ragel/host-go/Makefile.am
@@ -1,6 +1,9 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-go
-
 data_DATA = out-go.lm
+else
+noinst_PROGRAMS = ragel-go
+endif
 
 ragel_go_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-java/Makefile.am
+++ b/src/ragel/host-java/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-java
+else
+noinst_PROGRAMS = ragel-java
+endif
 
 ragel_java_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-js/Makefile.am
+++ b/src/ragel/host-js/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-js
+else
+noinst_PROGRAMS = ragel-js
+endif
 
 ragel_js_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-julia/Makefile.am
+++ b/src/ragel/host-julia/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-julia
+else
+noinst_PROGRAMS = ragel-julia
+endif
 
 ragel_julia_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-ocaml/Makefile.am
+++ b/src/ragel/host-ocaml/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-ocaml
+else
+noinst_PROGRAMS = ragel-ocaml
+endif
 
 ragel_ocaml_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-ruby/Makefile.am
+++ b/src/ragel/host-ruby/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-ruby
+else
+noinst_PROGRAMS = ragel-ruby
+endif
 
 ragel_ruby_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-rust/Makefile.am
+++ b/src/ragel/host-rust/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-rust
+else
+noinst_PROGRAMS = ragel-rust
+endif
 
 ragel_rust_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 

--- a/src/ragel/host-zig/Makefile.am
+++ b/src/ragel/host-zig/Makefile.am
@@ -1,4 +1,8 @@
+if INSTALL_RAGEL
 bin_PROGRAMS = ragel-zig
+else
+noinst_PROGRAMS = ragel-zig
+endif
 
 ragel_zig_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
 


### PR DESCRIPTION
Colm and ragel install together, all or nothing. A ragel user with no interest
in colm, or a colm user with no interest in ragel, has no way to narrow what
`make install` copies out. This adds a selector for each half to both build
systems.

```
./configure --disable-install-colm       cmake -DCOLM_INSTALL_COLM=OFF
./configure --disable-install-ragel      cmake -DCOLM_INSTALL_RAGEL=OFF
```

Both default on, so an unqualified build installs the whole suite exactly as
before. Turning both off is a configure error in each system, with a pointer to
`-DCOLM_MAKE_INSTALL=OFF` on the cmake side for the case where you genuinely
want no install rules.

## The build is unchanged

Only the install step narrows. The whole tree is still built in every
configuration, for two reasons: ragel's parsers are written in colm, so colm
has to be built before ragel can be, and building everything keeps the test
suite runnable from the build tree regardless of what you plan to install.

In the automake files this means the affected primaries move to their `noinst_`
counterparts rather than disappearing — `bin_PROGRAMS` to `noinst_PROGRAMS`,
`lib_LTLIBRARIES` to `noinst_LTLIBRARIES`. The one consequence worth flagging
is that libfsm and libragel become convenience libraries when ragel is not
being installed, so the ragel programs link them statically in that
configuration. The `-release` and `-no-undefined` flags are conditioned along
with them, since they do not apply to convenience libraries.

## What is in each half

**colm** — the `colm` program, `colm-wrap`, `include/colm/*.h`, `colm.vim`, and
the colm manual.

**ragel** — `ragel` and the thirteen host backends, libragel, libfsm and its
headers, `ragel.lm`, `out-go.lm`, the cgil `.lm` data and the twelve `cgil-*`
translators, `ragel.1`, `ragel.vim`, and the ragel guide.

**Both, always** — the colm runtime library and the aapl headers. Ragel links
libcolm, and the installed libfsm headers include aapl, so neither can be left
out of a ragel-only install and have it work. The colm cmake package goes out
for the same reason: the exported ragel targets name `colm::libcolm`.

cgil goes with ragel. The `rlhc-*.lm` sources translate ril, the intermediate
code generation language libfsm emits, and nothing in colm uses them.

## Verification

Install manifests, both build systems, three configurations each. In both the
colm-only and ragel-only manifests partition the full one exactly — every file
in the full install appears in one half or the other, and the overlap is
precisely the shared base named above (libcolm, the colm package files, and 38
aapl headers).

cmake:

```
ragel-only drops: bin/colm, include/colm/*.h (15), share/doc/colm-suite/colm.vim
colm-only keeps: the above, plus lib/libcolm.a and the colm cmake package
union == full install
```

autotools gives the same partition, with `bin/colm-wrap` and the libtool
artifacts on the colm side.

Beyond the manifests:

- `make check` passes in both restricted configurations — 1012 cases, 0
  failures each, across all five suites.
- `make dist` still works and ships every `CMakeLists.txt` and `*.cmake.in`.
- The installed ragel-only `ragel` compiles and runs a test machine, and `ldd`
  on `bin/ragel` and `bin/ragel-c` resolves libcolm, libfsm and libragel
  entirely inside that prefix.
- `find_package(ragel)` configures and builds against both the full and the
  ragel-only prefix.
- Both error paths behave, and `-DCOLM_MAKE_INSTALL=OFF` still generates no
  install rules at all.

## Note on the test harness

`test/Makefile.am` installs `runtests` into pkgdatadir unconditionally, and
`src/cgil/test/Makefile.am` does the same. Left alone — that is test
infrastructure rather than either half of the suite.
