### PR TITLE
docs: document host language selection as it actually works

### DIFF
--- a/doc/ragel/ragel-guide.txt
+++ b/doc/ragel/ragel-guide.txt
@@ -2766,22 +2766,25 @@ An example of line-oriented processing is given below.
 
 === Specifying the Host Language
 
-The `ragel` program has a number of options for specifying the host
-language. The host-language options are:
+The host language is determined by which program is run. There is one program
+per host language and they are installed alongside one another:
 
-* `-C` for C/C++/Objective-C code (default)
-* `--asm` or `--gas-x86-64-sys-v` for GNU AS, x86_64, System V ABI.
-* `-D` for D code.
-* `-Z` for Go code.
-* `-J` for Java code.
-* `-R` for Ruby code.
-* `-A` for C# code.
-* `-O` for OCaml code.
-* `-U` for Rust
-* `-B` for Zig
-* `-Y` for Julia
-* `-K` for Crack
-* `-P` for JavaScript
+* `ragel` or `ragel-c` for C, C++, Obj-C or Obj-C++ code
+* `ragel-asm` for GNU AS, x86_64, System V ABI
+* `ragel-d` for D code
+* `ragel-go` for Go code
+* `ragel-java` for Java code
+* `ragel-ruby` for Ruby code
+* `ragel-csharp` for C# code
+* `ragel-ocaml` for OCaml code
+* `ragel-rust` for Rust code
+* `ragel-zig` for Zig code
+* `ragel-julia` for Julia code
+* `ragel-crack` for Crack code
+* `ragel-js` for JavaScript code
+
+Ragel 6 selected the host language with a command-line option instead, such as
+`-Z` for Go. Those options do not exist in Ragel 7.
 
 [[genout]]
 === Choosing a Generated Code Style

--- a/doc/ragel/ragel.1.in
+++ b/doc/ragel/ragel.1.in
@@ -34,8 +34,9 @@ ragel \- compile regular languages into executable state machines
 .RI [ options ]
 .I file
 .SH DESCRIPTION
-Ragel compiles executable finite state machines from regular languages.  
-Ragel can generate C, C++, Objective-C, D, Go, or Java code. Ragel state
+Ragel compiles executable finite state machines from regular languages.
+Ragel can generate C, C++, Objective-C, D, Go, Java, Ruby, C#, OCaml, Rust,
+Zig, Julia, Crack, JavaScript or GNU AS x86-64 code. Ragel state
 machines can not only recognize byte
 sequences as regular expression machines do, but can also execute code at
 arbitrary points in the recognition of a regular language.  User code is
@@ -55,6 +56,52 @@ Ragel provides a very flexibile interface to the host language that attempts to
 place minimal restrictions on how the generated code is used and integrated
 into the application. The generated code has no dependencies.
 
+.SH HOST LANGUAGES
+The host language is determined by which program is run. There is one program
+per host language and they are installed alongside one another.
+.TP
+.BR ragel ", " ragel\-c
+C, C++, Obj\-C or Obj\-C++. All code styles supported.
+.TP
+.B ragel\-asm
+GNU AS, x86_64, System V ABI. Generated in a code style equivalent to \-G2.
+.TP
+.B ragel\-d
+D. All code styles supported.
+.TP
+.B ragel\-go
+Go. All code styles supported.
+.TP
+.B ragel\-zig
+Zig. All code styles supported.
+.TP
+.B ragel\-csharp
+C#. Code styles \-T0 \-T1 \-F0 \-F1 \-G0 \-G1.
+.TP
+.B ragel\-java
+Java. Code styles \-T0 \-T1 \-F0 \-F1.
+.TP
+.B ragel\-ruby
+Ruby. Code styles \-T0 \-T1 \-F0 \-F1.
+.TP
+.B ragel\-ocaml
+OCaml. Code styles \-T0 \-T1 \-F0 \-F1.
+.TP
+.B ragel\-rust
+Rust. Code styles \-T0 \-T1 \-F0 \-F1.
+.TP
+.B ragel\-julia
+Julia. Code styles \-T0 \-T1 \-F0 \-F1.
+.TP
+.B ragel\-crack
+Crack. Code styles \-T0 \-T1 \-F0 \-F1.
+.TP
+.B ragel\-js
+JavaScript. Code styles \-T0 \-T1 \-F0 \-F1.
+.PP
+Ragel 6 selected the host language with a command-line option instead, such as
+.B \-Z
+for Go. Those options do not exist in Ragel 7.
 .SH OPTIONS
 .TP
 .BR \-h ", " \-H ", " \-? ", " \-\-help
@@ -117,48 +164,8 @@ FSM specification to output.
 .B \-M <machine>
 Machine definition/instantiation to output.
 .TP
-.B \-C
-The host language is C, C++, Obj-C or Obj-C++. This is the default host language option.
-.TP
-.B --asm --gas-x86-64-sys-v
-GNU AS, x86_64, System V ABI
-ASM is generated in a code style equiv to -G2
-.TP
-.B \-D
-The host language is D.
-.TP
-.B \-Z
-The host language is Go.
-.TP
-.B \-J
-The host language is Java.
-.TP
-.B \-R
-The host language is Ruby.
-.TP
-.B -A
-The host language is C#
-.TP
-.B -O
-The host language is OCaml.
-.TP
-.B -U
-The host language is Rust.
-.TP
-.B -B
-The host language is Zig.
-.TP
-.B -Y
-The host language is Julia.
-.TP
-.B -K
-The host language is Crack.
-.TP
-.B -P
-The host language is JavaScript.
-.TP
 .B \-T0
-(C/D/Java/Ruby/C#) Generate a table driven FSM. This is the default code style.
+(all but ASM) Generate a table driven FSM. This is the default code style.
 The table driven
 FSM represents the state machine as static data. There are tables of states,
 transitions, indices and actions. The current state is stored in a variable.
@@ -170,21 +177,21 @@ compile but results in slower running code. The table driven FSM is suitable
 for any FSM.
 .TP
 .B \-T1
-(C/D/Ruby/C#) Generate a faster table driven FSM by expanding action lists in the action
+(all but ASM) Generate a faster table driven FSM by expanding action lists in the action
 execute code.
 .TP
 .B \-F0
-(C/D/Ruby/C#) Generate a flat table driven FSM. Transitions are represented as an array
+(all but ASM) Generate a flat table driven FSM. Transitions are represented as an array
 indexed by the current alphabet character. This eliminates the need for a
 binary search to locate transitions and produces faster code, however it is
 only suitable for small alphabets.
 .TP
 .B \-F1
-(C/D/Ruby/C#) Generate a faster flat table driven FSM by expanding action lists in the action
+(all but ASM) Generate a faster flat table driven FSM by expanding action lists in the action
 execute code.
 .TP
 .B \-G0
-(C/D/C#) Generate a goto driven FSM. The goto driven FSM represents the state machine
+(C, D, Go, C#, Zig) Generate a goto driven FSM. The goto driven FSM represents the state machine
 as a series of goto statements. While in the machine, the current state is
 stored by the processor's instruction pointer. The execution is a flat function
 where control is passed from state to state using gotos. In general, the goto
@@ -192,11 +199,11 @@ FSM produces faster code but results in a larger binary and a more expensive
 host language compile.
 .TP
 .B \-G1
-(C/D/C#) Generate a faster goto driven FSM by expanding action lists in the action
+(C, D, Go, C#, Zig) Generate a faster goto driven FSM by expanding action lists in the action
 execute code.
 .TP
 .B \-G2
-(C/D/Go) Generate a really fast goto driven FSM by embedding action lists in the state
+(C, D, Go, Zig, ASM) Generate a really fast goto driven FSM by embedding action lists in the state
 machine control code.
 .TP
 .B --nfa-conds-depth=D


### PR DESCRIPTION
The guide and the man page both said the host language is chosen with a command-line option, listing `-C` for C, `-Z` for Go, `-B` for Zig and so on. Ragel 7 has no such options.

Each host language is a separate program, with the language fixed at link time — `src/ragel/host-zig/main.cc` constructs `InputData id( &hostLangZig, &rlparseZig, &rlhcZig )`, and `inputdata.cc` has no `case 'Z'`, `case 'D'` or the rest. The usage output has listed the programs rather than the options since 7.0.4; only the documentation never caught up, and Zig inherited the pattern when the backend was added. `-B` is not a Zig option, or any option.

## What changed

Both documents now list the programs, with the code styles each supports, taken from the usage text so there is one source for it:

```
ragel, ragel-c    C, C++, Obj-C or Obj-C++    All code styles
ragel-asm         GNU AS, x86_64, System V    Equivalent to -G2
ragel-d           D                           All code styles
ragel-go          Go                          All code styles
ragel-zig         Zig                         All code styles
ragel-csharp      C#                          -T0 -T1 -F0 -F1 -G0 -G1
ragel-java, ragel-ruby, ragel-ocaml, ragel-rust,
ragel-julia, ragel-crack, ragel-js            -T0 -T1 -F0 -F1
```

Each document also notes that Ragel 6 used options such as `-Z`, which should save anyone carrying an old build script some time.

Two further things in the same area were out of date:

- The man page's code style entries name which languages support each style. `-T0` said "(C/D/Java/Ruby/C#)" and `-G2` said "(C/D/Go)". They now read "(all but ASM)" and "(C, D, Go, Zig, ASM)", matching the guide's table.
- The man page's description claimed Ragel generates "C, C++, Objective-C, D, Go, or Java" code. That is six of fourteen.

The guide's code style table was already correct, Zig row included, and is untouched.

## Verification

The man page regenerates cleanly and substitutes its version, which it started doing in #220:

```
.TH RAGEL 1 "April 2026" "Ragel 7.1.0-pre.1" "Ragel State Machine Compiler"
```

Every `.TP` is followed by a font macro and the section structure is intact. There is no `groff` or working `man` on the machine I am on, so I have not seen it rendered — worth a look from someone who can. The section is written with the same plain `.TP` entries used through the rest of the page rather than anything more compact, to keep that risk small.
