### PR TITLE
Fix the go, rust, ocaml and julia backends broken since the chained-subscript change

### DIFF
--- a/src/cgil/ril.lm
+++ b/src/cgil/ril.lm
@@ -98,7 +98,6 @@ def expr_factor
 |	[string]     :String
 |	[embedded_host `-> expr_factor] :Access
 |	[`( expr `)] :Paren
-|	[`cast `( type `) expr_factor] :Cast
 
 def lvalue
 	[embedded_host]
@@ -110,6 +109,7 @@ def lvalue
 def expr_factor_op
 	[`! expr_factor_op]
 |	[`~ expr_factor_op]
+|	[`cast `( type `) expr_factor_op]
 |	[expr_factor]
 
 def expr_bitwise

--- a/src/cgil/rlhc-c.lm
+++ b/src/cgil/rlhc-c.lm
@@ -140,10 +140,6 @@ namespace c_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast `( T: type `) F: expr_factor]
-		{
-			<<	"( [type( T )] ) [expr_factor( F )]"
-		}
 		default {
 			# Catches cases not specified
 			<<	[ExprFactor]
@@ -187,6 +183,10 @@ namespace c_gen
 		case [T: `~ expr_factor_op]
 		{
 			<<	['~' expr_factor_op( _expr_factor_op )]
+		}
+		case [`cast `( T: type `) F: expr_factor_op]
+		{
+			<<	"( [type( T )] ) [expr_factor_op( F )]"
 		}
 		case [expr_factor]
 		{

--- a/src/cgil/rlhc-crack.lm
+++ b/src/cgil/rlhc-crack.lm
@@ -149,11 +149,6 @@ namespace crack_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast `( T: type `) F: expr_factor]
-		{
-			send Parser 
-				"[type( T )] ( [expr_factor( F )] )"
-		}
 		case [I: ident `[ E: expr `] `. F: ident] {
 			send Parser
 				[^I '_' ^F '[' E ']']
@@ -205,6 +200,11 @@ namespace crack_gen
 		{
 			send Parser [T]
 			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast `( T: type `) F: expr_factor_op]
+		{
+			send Parser
+				"[type( T )] ( [expr_factor_op( F )] )"
 		}
 		case [expr_factor]
 		{

--- a/src/cgil/rlhc-csharp.lm
+++ b/src/cgil/rlhc-csharp.lm
@@ -142,13 +142,6 @@ namespace csharp_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast Open: `( Type: type Close: `) expr_factor]
-		{
-			send Parser [Open]
-			type( Type )
-			send Parser [Close]
-			expr_factor( ExprFactor._expr_factor )
-		}
 		default {
 			# Catches cases not specified
 			send Parser [ExprFactor]
@@ -190,6 +183,13 @@ namespace csharp_gen
 		case [T: `~ expr_factor_op]
 		{
 			send Parser [T]
+			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast Open: `( Type: type Close: `) expr_factor_op]
+		{
+			send Parser [Open]
+			type( Type )
+			send Parser [Close]
 			expr_factor_op( ExprFactorOp._expr_factor_op )
 		}
 		case [expr_factor]

--- a/src/cgil/rlhc-d.lm
+++ b/src/cgil/rlhc-d.lm
@@ -161,13 +161,6 @@ namespace d_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast Open: `( Type: type Close: `) expr_factor]
-		{
-			send Parser ['cast' Open]
-			type( Type )
-			send Parser [Close]
-			expr_factor( ExprFactor._expr_factor )
-		}
 		default {
 			# Catches cases not specified
 			send Parser [ExprFactor]
@@ -210,6 +203,13 @@ namespace d_gen
 		case [T: `~ expr_factor_op]
 		{
 			send Parser [T]
+			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast Open: `( Type: type Close: `) expr_factor_op]
+		{
+			send Parser ['cast' Open]
+			type( Type )
+			send Parser [Close]
 			expr_factor_op( ExprFactorOp._expr_factor_op )
 		}
 		case [expr_factor]

--- a/src/cgil/rlhc-go.lm
+++ b/src/cgil/rlhc-go.lm
@@ -131,10 +131,6 @@ namespace go_gen
 			embedded_host(embedded_host)
 			expr_factor(_expr_factor)
 		}
-		case Cast
-		{
-			<<	[type(type) '( ' expr_factor(_expr_factor) ' )' ]
-		}
 		default {
 			# Catches cases not specified
 			<<	[ExprFactor]
@@ -173,6 +169,10 @@ namespace go_gen
 		case [T: `~ expr_factor_op]
 		{
 			<<	['^ ' expr_factor_op( _expr_factor_op )]
+		}
+		case [`cast `( T: type `) F: expr_factor_op]
+		{
+			<<	[type(T) '( ' expr_factor_op(F) ' )' ]
 		}
 		case [expr_factor]
 		{

--- a/src/cgil/rlhc-java.lm
+++ b/src/cgil/rlhc-java.lm
@@ -155,13 +155,6 @@ namespace java_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast Open: `( Type: type Close: `) expr_factor]
-		{
-			send Parser [Open]
-			type( Type )
-			send Parser [Close]
-			expr_factor( ExprFactor._expr_factor )
-		}
 		case [I: ident `[ E: expr `] `. F: ident] {
 			send Parser
 				[^I '_' ^F '[' E ']']
@@ -212,6 +205,13 @@ namespace java_gen
 		case [T: `~ expr_factor_op]
 		{
 			send Parser [T]
+			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast Open: `( Type: type Close: `) expr_factor_op]
+		{
+			send Parser [Open]
+			type( Type )
+			send Parser [Close]
 			expr_factor_op( ExprFactorOp._expr_factor_op )
 		}
 		case [expr_factor]

--- a/src/cgil/rlhc-js.lm
+++ b/src/cgil/rlhc-js.lm
@@ -153,10 +153,6 @@ namespace js_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast Open: `( type Close: `) expr_factor]
-		{
-			expr_factor( ExprFactor._expr_factor )
-		}
 		default {
 			# Catches cases not specified
 			send Parser [ExprFactor]
@@ -204,6 +200,10 @@ namespace js_gen
 		case [T: `~ expr_factor_op]
 		{
 			send Parser [T]
+			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast `( type `) expr_factor_op]
+		{
 			expr_factor_op( ExprFactorOp._expr_factor_op )
 		}
 		case [expr_factor]

--- a/src/cgil/rlhc-julia.lm
+++ b/src/cgil/rlhc-julia.lm
@@ -6,8 +6,8 @@ namespace julia_out
 
 	lex
 		token comment /
-			'//' any* :> '\n' |
-			'/*' any* :>> '*/'
+			'#=' any* :>> '=#' |
+			'#' any* :> '\n'
 		/
 
 		literal `function `end `while `if `else `elseif
@@ -20,7 +20,7 @@ namespace julia_out
 		/
 
 		token symbol /
-			'!' | '#' | '$' | '%' | '&' | '(' | ')' | '*' |
+			'!' | '$' | '%' | '&' | '(' | ')' | '*' |
 			'+' | ',' | '-' | '.' | '/' | ':' | ';' | '<' |
 			'=' | '>' | '?' | '@' | '[' | ']' | '^' | '|' |
 			'~' /

--- a/src/cgil/rlhc-julia.lm
+++ b/src/cgil/rlhc-julia.lm
@@ -157,11 +157,6 @@ namespace julia_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast `( T: type `) F: expr_factor]
-		{
-			send Parser 
-				"convert([type( T )], [expr_factor( F )] )"
-		}
 		case [I: ident `[ E: expr `] `. F: ident] {
 			send Parser
 				[^I '_' ^F '[1+(' expr(E) ')]']
@@ -213,6 +208,11 @@ namespace julia_gen
 		{
 			send Parser [T]
 			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast `( T: type `) F: expr_factor_op]
+		{
+			send Parser
+				"convert([type( T )], [expr_factor_op( F )] )"
 		}
 		case [expr_factor]
 		{

--- a/src/cgil/rlhc-ocaml.lm
+++ b/src/cgil/rlhc-ocaml.lm
@@ -183,11 +183,6 @@ namespace ml_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast `( type `) expr_factor]
-		{
-			send Parser
-				[expr_factor( ExprFactor._expr_factor )]
-		}
 		case [I: ident `[ E: expr `] `. F: ident] {
 			send Parser
 				[^I '_' ^F '[' E ']']
@@ -238,6 +233,10 @@ namespace ml_gen
 		case [T: `~ expr_factor_op]
 		{
 			send Parser " lnot "
+			expr_factor_op( ExprFactorOp._expr_factor_op )
+		}
+		case [`cast `( type `) expr_factor_op]
+		{
 			expr_factor_op( ExprFactorOp._expr_factor_op )
 		}
 		case [expr_factor]

--- a/src/cgil/rlhc-ocaml.lm
+++ b/src/cgil/rlhc-ocaml.lm
@@ -113,11 +113,11 @@ namespace ml_gen
 			# static/dynamic arrays. Really the CGIL needs to distinuish.
 			if ( StaticVarMap->find( $I ) || $I == 'stack' ) {
 				send Parser
-					"[ ExprFactor.ident ].([ expr( TL ) ])"
+					"[ I ].([ expr( TL ) ])"
 			}
 			else {
 				send Parser
-					"[ ExprFactor.ident ].\[[ expr( TL ) ]\]"
+					"[ I ].\[[ expr( TL ) ]\]"
 			}
 		}
 		case [EF: expr_factor `[ TL: expr `]] {

--- a/src/cgil/rlhc-ruby.lm
+++ b/src/cgil/rlhc-ruby.lm
@@ -153,13 +153,6 @@ void expr_factor( ExprFactor: expr_factor )
 		embedded_host( E1 )
 		expr_factor( E2 )
 	}
-	case [`cast Open: `( Type: type Close: `) expr_factor]
-	{
-		#send Parser [Open]
-		#type( Type )
-		#send Parser [Close]
-		expr_factor( ExprFactor._expr_factor )
-	}
 	case [I: ident `[ E: expr `] `. F: ident] {
 		send Parser
 			[^I '_' ^F '[' E ']']
@@ -209,6 +202,10 @@ void expr_factor_op( ExprFactorOp: expr_factor_op )
 	case [T: `~ expr_factor_op]
 	{
 		send Parser [T]
+		expr_factor_op( ExprFactorOp._expr_factor_op )
+	}
+	case [`cast `( type `) expr_factor_op]
+	{
 		expr_factor_op( ExprFactorOp._expr_factor_op )
 	}
 	case [expr_factor]

--- a/src/cgil/rlhc-rust.lm
+++ b/src/cgil/rlhc-rust.lm
@@ -144,11 +144,6 @@ namespace rust_gen
 			embedded_host( E1 )
 			expr_factor( E2 )
 		}
-		case [`cast `( T: type `) E: expr_factor]
-		{
-			send Parser
-				"( [expr_factor( E )] ) as [type(T)]"
-		}
 		case [I: ident `[ E: expr `] `. F: ident] {
 			send Parser
 				[^I '_' ^F '[' expr(E) ' as usize]']
@@ -200,6 +195,11 @@ namespace rust_gen
 		{
 			send Parser
 				"![expr_factor_op( EFO )]
+		}
+		case [`cast `( T: type `) E: expr_factor_op]
+		{
+			send Parser
+				"( [expr_factor_op( E )] ) as [type(T)]"
 		}
 		case [expr_factor]
 		{

--- a/src/cgil/rlhc-zig.lm
+++ b/src/cgil/rlhc-zig.lm
@@ -136,21 +136,9 @@ namespace zig_gen
 		}
 		case [Base: expr_factor `[ Sub: expr `]]
 		{
-			# RIL is written with C precedence, where 'cast(uint)a[i]'
-			# casts the element. The grammar here is left recursive on the
-			# subscript, so it binds as '(cast(uint)a)[i]' instead. Undo
-			# that, otherwise we would be casting the array itself.
-			#
 			# Zig indexes with usize. Narrower unsigned types widen
 			# implicitly but signed ones do not, so cast every subscript.
-			if match Base [`cast `( T: type `) Inner: expr_factor] {
-				<<	["@as( " type(T) ", @intCast( "
-						expr_factor(Inner) '\[@intCast( ' expr( Sub ) ' )\]'
-						" ) )"]
-			}
-			else {
-				<<	[expr_factor(Base) '\[@intCast( ' expr( Sub ) ' )\]']
-			}
+			<<	[expr_factor(Base) '\[@intCast( ' expr( Sub ) ' )\]']
 		}
 		case ArraySubField
 		{
@@ -182,10 +170,6 @@ namespace zig_gen
 		{
 			embedded_host(embedded_host)
 			expr_factor(_expr_factor)
-		}
-		case Cast
-		{
-			<<	["@as( " type(type) ", @intCast( " expr_factor(_expr_factor) " ) )" ]
 		}
 		default {
 			<<	[ExprFactor]
@@ -228,6 +212,10 @@ namespace zig_gen
 		{
 			# Zig needs comptime_int width for bitwise NOT; cast to i32.
 			<<	['~@as( i32, @intCast( ' expr_factor_op( _expr_factor_op ) ' ) )']
+		}
+		case [`cast `( T: type `) F: expr_factor_op]
+		{
+			<<	["@as( " type(T) ", @intCast( " expr_factor_op(F) " ) )" ]
 		}
 		case [expr_factor]
 		{

--- a/src/cgil/test/cases/test-go-02.go
+++ b/src/cgil/test/cases/test-go-02.go
@@ -1,0 +1,9 @@
+var _offsets = [] int8 { 0, 0, 1, 0 }
+{
+	var _trans uint  = 0
+	var cs int  = 0
+	_trans=uint( _offsets[ cs ] );
+	_trans=uint( _offsets[ cs ][ 0 ] );
+	_trans=uint( ! cs );
+	
+}

--- a/src/cgil/test/cases/test-go-02.ri
+++ b/src/cgil/test/cases/test-go-02.ri
@@ -1,0 +1,9 @@
+array s8 _offsets( 0, 1 ) = { 0, 0, 1, 0 };
+
+{
+	uint _trans = 0;
+	int cs = 0;
+	_trans = cast(uint)_offsets[cs];
+	_trans = cast(uint)_offsets[cs][0];
+	_trans = cast(uint)!cs;
+}

--- a/src/cgil/test/cases/test-ocaml-01.ocaml
+++ b/src/cgil/test/cases/test-ocaml-01.ocaml
@@ -1,0 +1,10 @@
+let _offsets : int array = [|
+0; 0; 1; 0 ; 
+|]
+begin
+	let _trans  : int  ref = ref ( 0 ) in
+	let cs  : int  ref = ref ( 0 ) in
+	_trans  := _offsets.(cs.contents);
+	cs  := _stack.[top.contents];
+	
+end;

--- a/src/cgil/test/cases/test-ocaml-01.ri
+++ b/src/cgil/test/cases/test-ocaml-01.ri
@@ -1,0 +1,8 @@
+array s8 _offsets( 0, 1 ) = { 0, 0, 1, 0 };
+
+{
+	uint _trans = 0;
+	int cs = 0;
+	_trans = cast(uint)_offsets[cs];
+	cs = _stack[top];
+}

--- a/src/ragel/ChangeLog
+++ b/src/ragel/ChangeLog
@@ -31,6 +31,9 @@ Ragel 7.1.0 - Aug 19, 2026
   the size of the signed types.
  -Host language comments are retained across the intermediate language and
   now survive into the generated code.
+ -Julia: the host lexer now recognizes julia comments, # and #= =#, in place
+  of the C forms // and /* */ it wrongly inherited. Julia host code that
+  relied on ragel consuming C-style comments must switch to julia syntax.
  -Rust: permit the apostrophe in output, and improved lexing of character
   literals and identifiers, including lifetimes, in the host scanner.
  -Intermediate language: allow an expression as the base of a deref or

--- a/src/ragel/host-julia/rlparse.lm
+++ b/src/ragel/host-julia/rlparse.lm
@@ -21,6 +21,9 @@ rl c_comment
 rl cpp_comment
 	/ '//' [^\n]* NL /
 
+rl julia_comment
+	/ '#=' ( any | NL )* :>> '=#' | '#' [^\n]* NL /
+
 rl s_literal
 	/ "'" ([^'\\\n] | '\\' (any | NL))* "'" /
 
@@ -39,7 +42,7 @@ namespace inline
 		token dec_number /'0x' [0-9a-fA-F]+/
 
 		token comment
-			/ c_comment | cpp_comment /
+			/ julia_comment /
 
 		token string
 			/ s_literal | d_literal /
@@ -113,7 +116,7 @@ namespace host
 		token hex_number /'0x' [0-9a-fA-F]+/
 
 		token comment
-			/ c_comment | cpp_comment /
+			/ julia_comment /
 
 		token string
 			/ s_literal | d_literal /

--- a/test/ragel.d/julia1.rl
+++ b/test/ragel.d/julia1.rl
@@ -1,4 +1,4 @@
-// @LANG: julia 
+# @LANG: julia
 
 %%{
 	machine atoi;

--- a/test/ragel.d/trans-julia.lm
+++ b/test/ragel.d/trans-julia.lm
@@ -264,17 +264,17 @@ void julia( Output: stream )
 	}
 
 	send Output
-		"//
-		"// @LANG: julia
-		"// @GENERATED: true
+		"#
+		"# @LANG: julia
+		"# @GENERATED: true
 
 	if ProhibitGenflags {
 		send Output
-			"// @PROHIBIT_GENFLAGS:[ProhibitGenflags]
+			"# @PROHIBIT_GENFLAGS:[ProhibitGenflags]
 	}
 
 	send Output
-		"//
+		"#
 		"
 
 

--- a/test/ragel.d/url1.rl
+++ b/test/ragel.d/url1.rl
@@ -119,7 +119,7 @@ let parse_authority u data =
 		action mark      { mark := !p                             }
 		action str_start { Buffer.reset buf                       }
 		action str_char  { Buffer.add_char buf data.[p.contents]                }
-		action str_lower { Buffer.add_char buf (Char.lowercase data.[p.contents])}
+		action str_lower { Buffer.add_char buf (Char.lowercase_ascii data.[p.contents])}
 		action hex_hi    { hex := unhex data.[p.contents] * 16                   }
 		action hex_lo    { Buffer.add_char buf (Char.chr (!hex + unhex data.[p.contents])) }
 		action copy_b1     { b1 := Buffer.contents buf; Buffer.clear buf }
@@ -260,7 +260,7 @@ let url_parse data =
 		action mark      { mark := !p                             }
 		action str_start { Buffer.reset buf                       }
 		action str_char  { Buffer.add_char buf data.[p.contents]                 }
-		action str_lower { Buffer.add_char buf (Char.lowercase data.[p.contents])}
+		action str_lower { Buffer.add_char buf (Char.lowercase_ascii data.[p.contents])}
 		action hex_hi    { hex := unhex data.[p.contents] * 16                   }
 		action hex_lo    { Buffer.add_char buf (Char.chr (!hex + unhex data.[p.contents])) }
 		action scheme    { u := { !u with scheme = Buffer.contents buf } }


### PR DESCRIPTION
Running the full test suite in the new dev image (#223) showed every go, rust, ocaml and julia case failing — 1152 tests. These backends had been silently broken because their toolchains were never installed until now. Four fixes:

## cgil: lift cast out of expr_factor so it applies after subscripts

Since a45830e0 array subscripts chain on `expr_factor`, which made `cast(T) a[i]` ambiguous; the parser reduced the cast first, giving `(cast(T) a)[i]`. The C-family backends survived by luck of syntax (`(uint)a[i]` reads the same either way in C), but go, rust, ocaml and julia emitted a cast of the array itself, and zig carried a hand-written workaround that re-associated the tree.

The `cast` production moves up to `expr_factor_op`, alongside the unary operators, where it is right recursive — subscripts complete before a cast can apply. All 12 backends now match it there and render the operand with `expr_factor_op`; the zig workaround is gone. New cgil case `test-go-02` covers a cast of a single subscript, a chained subscript, and a unary operand.

## cgil: fix the ocaml translator crashing on array subscripts

The ident-subscript case in `rlhc-ocaml.lm` still matched after a45830e0 but read `ExprFactor.ident`, no longer a direct child of the subscript node. Building output from the nil crashed the translator (94 segfaults in the suite run) and left every ocaml output file empty. It now uses the captured ident. New cgil case `test-ocaml-01` covers the static and dynamic (stack) forms.

## ragel julia: lex julia comments rather than C comments

The julia front end was cloned from the C one: it lexed `//` and `/* */` as host comments and did not know `#` or `#= =#`. Wrong for real julia sources (a `'` inside a `#` comment opened a string literal), and it let the test generator and julia1.rl use `//` headers that ragel silently consumed — until 9685806d began retaining host comments, at which point the headers reached julia and every julia test failed to parse.

**Behaviour change:** julia host code that relied on ragel eating C-style comments must switch to julia syntax. Noted in the ragel 7.1.0 ChangeLog entry.

## test: use Char.lowercase_ascii in the ocaml url1 case

`Char.lowercase` was removed in OCaml 5.

## Verification

Built and run on main + this branch in the #223 image (arm64): cgil harness passes; full `test/runtests` runs 6043 cases with go 456, rust 234, ocaml 234, julia 342 and D 456 (trans-generated) all passing. The 148 remaining failures are pre-existing and untouched here: genrep1/2/5/6/7/8 and nfa3 (C runtime crashes), tsreset (C++), and 48 hand-written D cases (clang3, cppscan4/5, export4) that gdc 15 rejects for C-style array syntax and implicit string concatenation.