### PR TITLE
Fix the crashing genrep and nfa3 tests: writable, typed NFA backtrack stack

### DIFF
--- a/test/ragel.d/genrep1.rl
+++ b/test/ragel.d/genrep1.rl
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -24,6 +22,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine genrep;
@@ -77,7 +77,7 @@ int test( const char *p )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 

--- a/test/ragel.d/genrep2.rl
+++ b/test/ragel.d/genrep2.rl
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -24,6 +22,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine genrep;
@@ -80,7 +80,7 @@ int test( const char *p )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 

--- a/test/ragel.d/genrep5.rl
+++ b/test/ragel.d/genrep5.rl
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -24,6 +22,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine genrep;
@@ -82,7 +82,7 @@ int test( const char *p )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 

--- a/test/ragel.d/genrep6.rl
+++ b/test/ragel.d/genrep6.rl
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -24,6 +22,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine genrep;
@@ -90,7 +90,7 @@ int test( int c1, int c2, const char *p )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 	long q_2 = 0;

--- a/test/ragel.d/genrep7.rl
+++ b/test/ragel.d/genrep7.rl
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -24,6 +22,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine genrep;
@@ -76,7 +76,7 @@ int test( const char *p )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 

--- a/test/ragel.d/genrep8.rl
+++ b/test/ragel.d/genrep8.rl
@@ -10,8 +10,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -25,6 +23,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine genrep;
@@ -76,7 +76,7 @@ int test( const char *p )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 

--- a/test/ragel.d/nfa3.rl
+++ b/test/ragel.d/nfa3.rl
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-const char s[4096];
-
 struct nfa_stack
 {
 	void *data;
@@ -24,6 +22,8 @@ struct nfa_bp_rec
 	long popTrans;
 	long q_2;
 };
+
+static struct nfa_bp_rec s[128];
 
 %%{
 	machine atoi;
@@ -60,7 +60,7 @@ int test( const char *p, bool a, bool b )
 	const char *eof = pe;
 	int cs;
 
-	struct nfa_bp_rec *nfa_bp = (struct nfa_bp_rec*) s;
+	struct nfa_bp_rec *nfa_bp = s;
 	long nfa_len = 0;
 	long nfa_count = 0;
 


### PR DESCRIPTION
The hand-written C cases genrep1, genrep2, genrep5 through genrep8 and nfa3 declared their NFA backtrack stack as

```c
const char s[4096];
```

and cast it to `struct nfa_bp_rec *` for writing. Current gcc places the const tentative definition in read-only memory, so the first backtrack push segfaulted; the crash discarded buffered stdout, which is why every variant failed with empty output (88 cases across the code styles plus the `--string-tables` variants).

Declare the stack as `static struct nfa_bp_rec s[128];` instead and drop the cast. That makes it writable, keeps at least the old 4096-byte capacity, and also removes the alignment UB of casting a `char` array to a struct of longs. Same two-line change in each of the seven files; expected output untouched.

## Verification

In the dev image (arm64): `../runtests -C` (2163 cases) and `../runtests -C --string-tables` — all genrep/nfa3 variants now pass. The only remaining C failures are the 13 `tsreset` cases, which are the known, pre-existing issue #76 regression (`ts` set at EOF by from-state actions) and are deliberately not touched here.
