### PR TITLE
Fix the hand-written D tests rejected by gdc 15

### DIFF
--- a/test/ragel.d/clang3.rl
+++ b/test/ragel.d/clang3.rl
@@ -194,44 +194,44 @@ void test( const char[] buf )
 int main()
 {
 	test( 
-		"999 0xaAFF99 99.99 /*\n"
-		"*/ 'lksdj' //\n"
-		"\"\n"
-		"\n"
-		"literal\n"
-		"\n"
-		"\n"
+		"999 0xaAFF99 99.99 /*\n" ~
+		"*/ 'lksdj' //\n" ~
+		"\"\n" ~
+		"\n" ~
+		"literal\n" ~
+		"\n" ~
+		"\n" ~
 		"\"0x00aba foobardd.ddsf 0x0.9\n" );
 
 	test( 
-		"wordwithnum00asdf\n"
-		"000wordfollowsnum,makes new symbol\n"
-		"\n"
+		"wordwithnum00asdf\n" ~
+		"000wordfollowsnum,makes new symbol\n" ~
+		"\n" ~
 		"finishing early /* unfinished ...\n" );
 
 	test( 
-		"/*\n"
-		" *  Copyright\n"
-		" */\n"
-		"\n"
-		"/*  Aapl.\n"
-		" */\n"
-		"\n"
-		"#define _AAPL_RESIZE_H\n"
-		"\n"
-		"#include <assert.h>\n"
-		"\n"
-		"#ifdef AAPL_NAMESPACE\n"
-		"namespace Aapl {\n"
-		"#endif\n"
-		"#define LIN_DEFAULT_STEP 256\n"
-		"#define EXPN_UP( existing, needed ) \\\n"
-		"		need > eng ? (ned<<1) : eing\n"
-		"	\n"
-		"\n"
-		"/*@}*/\n"
-		"#undef EXPN_UP\n"
-		"#ifdef AAPL_NAMESPACE\n"
+		"/*\n" ~
+		" *  Copyright\n" ~
+		" */\n" ~
+		"\n" ~
+		"/*  Aapl.\n" ~
+		" */\n" ~
+		"\n" ~
+		"#define _AAPL_RESIZE_H\n" ~
+		"\n" ~
+		"#include <assert.h>\n" ~
+		"\n" ~
+		"#ifdef AAPL_NAMESPACE\n" ~
+		"namespace Aapl {\n" ~
+		"#endif\n" ~
+		"#define LIN_DEFAULT_STEP 256\n" ~
+		"#define EXPN_UP( existing, needed ) \\\n" ~
+		"		need > eng ? (ned<<1) : eing\n" ~
+		"	\n" ~
+		"\n" ~
+		"/*@}*/\n" ~
+		"#undef EXPN_UP\n" ~
+		"#ifdef AAPL_NAMESPACE\n" ~
 		"#endif /* _AAPL_RESIZE_H */\n" );
 	return 0;
 }

--- a/test/ragel.d/cppscan4.rl
+++ b/test/ragel.d/cppscan4.rl
@@ -234,36 +234,36 @@ void test(const(char)[] buf)
 int main()
 {
 	test(
-		"/*\n"
-		" *  Copyright \n"
-		" */\n"
-		"\n"
-		"RedTransAp *RedFsmAp::reduceTrans( TransAp *trans )\n"
-		"{\n"
-		"	RedAction *action = 0;\n"
-		"	if ( trans->actionTable.length() > 0 ) {\n"
-		"		if ( actionMap.insert( trans->actionTable, &action ) )\n"
-		"			action->id = nextActionId++;\n"
-		"	}\n"
-		"	\n"
-		"	RedStateAp *targ = (RedStateAp*)trans->toState;\n"
-		"	if ( action == 0 ) {\n"
-		"		delete trans;\n"
-		"		return 0;\n"
-		"	}\n"
-		"\n"
-		"	trans->~TransAp();\n"
-		"	inDict = new(trans) RedTransAp( targ, action, nextTransId++ );\n"
-		"	transSet.insert( inDict );\n"
+		"/*\n" ~
+		" *  Copyright \n" ~
+		" */\n" ~
+		"\n" ~
+		"RedTransAp *RedFsmAp::reduceTrans( TransAp *trans )\n" ~
+		"{\n" ~
+		"	RedAction *action = 0;\n" ~
+		"	if ( trans->actionTable.length() > 0 ) {\n" ~
+		"		if ( actionMap.insert( trans->actionTable, &action ) )\n" ~
+		"			action->id = nextActionId++;\n" ~
+		"	}\n" ~
+		"	\n" ~
+		"	RedStateAp *targ = (RedStateAp*)trans->toState;\n" ~
+		"	if ( action == 0 ) {\n" ~
+		"		delete trans;\n" ~
+		"		return 0;\n" ~
+		"	}\n" ~
+		"\n" ~
+		"	trans->~TransAp();\n" ~
+		"	inDict = new(trans) RedTransAp( targ, action, nextTransId++ );\n" ~
+		"	transSet.insert( inDict );\n" ~
 		"}\n"
 	);
 
 	test(
-		"->*\n"
-		".*\n"
-		"/*\"*/\n"
-		"\"/*\"\n"
-		"L'\"'\n"
+		"->*\n" ~
+		".*\n" ~
+		"/*\"*/\n" ~
+		"\"/*\"\n" ~
+		"L'\"'\n" ~
 		"L\"'\"\n"
 	);
 

--- a/test/ragel.d/cppscan5.rl
+++ b/test/ragel.d/cppscan5.rl
@@ -163,7 +163,7 @@ class Scanner
 
 static const int BUFSIZE = 12;
 
-void test( const(char) buf[] )
+void test( const(char)[] buf )
 {
 	Scanner scanner = new Scanner();
 	scanner.init();
@@ -179,31 +179,31 @@ void test( const(char) buf[] )
 int main()
 {
 	test(
-		"\"\\\"hi\" /*\n"
-		"*/\n"
-		"44 .44\n"
-		"44. 44\n"
-		"44 . 44\n"
-		"44.44\n"
+		"\"\\\"hi\" /*\n" ~
+		"*/\n" ~
+		"44 .44\n" ~
+		"44. 44\n" ~
+		"44 . 44\n" ~
+		"44.44\n" ~
 		"_hithere22"
 	);
 
 	test(
-		"'\\''\"\\n\\d'\\\"\"\n"
-		"hi\n"
-		"99\n"
-		".99\n"
-		"99e-4\n"
-		"->*\n"
-		"||\n"
-		"0x98\n"
-		"0x\n"
-		"//\n"
+		"'\\''\"\\n\\d'\\\"\"\n" ~
+		"hi\n" ~
+		"99\n" ~
+		".99\n" ~
+		"99e-4\n" ~
+		"->*\n" ~
+		"||\n" ~
+		"0x98\n" ~
+		"0x\n" ~
+		"//\n" ~
 		"/* * */"
 	);
 
 	test(
-		"'\n"
+		"'\n" ~
 		"'\n"
 	);
 

--- a/test/ragel.d/export4.rl
+++ b/test/ragel.d/export4.rl
@@ -24,7 +24,7 @@ import std.string;
 %% write exports;
 %% write data;
 
-int test( char data[] )
+int test( char[] data )
 {
 	int cs = test_en_commands;
 	char *p = data.ptr, pe = data.ptr + data.length;
@@ -39,7 +39,7 @@ int test( char data[] )
 	return 0;
 }
 
-char data[] = [ 
+char[] data = [ 
 	test_ex_c1, '1', '2', '\n', 
 	test_ex_c2, 'a', 'b', '\n', 
 	test_ex_c3, '.', '.', '\n'


### PR DESCRIPTION
gdc 15 (ubuntu 26.04) turned two long-deprecated D constructs into hard errors, which broke the four hand-written D cases — clang3, cppscan4, cppscan5 and export4, 48 test variants in all. These went unnoticed until the dev image gained a D compiler (#223): configure's old `gdc-8`..`gdc-5` probe chain meant D had been silently skipped for years.

- **Implicit concatenation of adjacent string literals is disallowed.** The multi-line test-input strings in clang3, cppscan4 and cppscan5 are now joined with `~` (75 sites). String contents are unchanged, so expected output is untouched.
- **C-style array declarations are rejected.** `int test( char data[] )` and `char data[] = [...]` in export4, and `void test( const(char) buf[] )` in cppscan5, become D-style `char[] data` / `const(char)[] buf`.

## Verification

In the dev image (arm64): `../runtests -D` — all 504 D cases pass. Full `test/ragel.d` run: 5564 cases, with the only remaining failures the 13 known `tsreset` cases (issue #76, `ts` set at EOF by from-state actions), to be addressed separately by porting the `set-ts-on-first-char` branch.