### PR TITLE
Regenerate the ragel man page when the version or date change

### DIFF
--- a/doc/ragel/Makefile.am
+++ b/doc/ragel/Makefile.am
@@ -34,7 +34,7 @@ EXTRA_DIST = ragel-guide.txt ragel.1.in \
 	bmrange.fig conds2.fig exconcat.fig exor.fig exstar.fig lines1.fig \
 	opstar.fig
 
-ragel.1: ragel.1.in
+ragel.1: ragel.1.in Makefile
 	@$(top_srcdir)/sedsubst $< $@ -w,+x $(SED_SUBST)
 
 if BUILD_MANUAL


### PR DESCRIPTION
`doc/ragel/ragel.1` is generated from `ragel.1.in` via `sedsubst`, taking `@RAGEL_VERSION@` and `@RAGEL_PUBDATE@` from `SED_SUBST` — but the make rule depended only on the `.in` file. A version or PUBDATE bump in configure.ac never touched the `.in`, so an already-built man page went stale and would ship with the old version and date on the next release.

Add `Makefile` to the rule's prerequisites — that is where `SED_SUBST` is defined, and config.status rewrites it whenever configure changes. Same dependency pattern the tree already uses for `gentests`, `subject.mk` and `subject.sh` in `test/`.

## Verification

`make -C doc/ragel ragel.1` builds the page (`.TH RAGEL 1 "April 2026" "Ragel 7.1.0-pre.1" ...`); a second make is a no-op; after the Makefile is regenerated the substitution re-runs and the page is rebuilt.