### PR TITLE
Version libfsm by colm and unskip the asm tests on PIE-default gcc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -400,13 +400,13 @@ main:
 EOF
 
 AC_MSG_CHECKING([checking if ragel ASM tests will build ... ])
-if sh -c "$ASM_BIN -o conftest.bin conftest.s" >>config.log 2>&1; then
+if sh -c "$ASM_BIN -no-pie -o conftest.bin conftest.s" >>config.log 2>&1; then
 	AC_MSG_RESULT([yes])
 else
 	AC_MSG_RESULT([no])
 	ASM_BIN=""
 fi
-rm -f conftest.s
+rm -f conftest.s conftest.bin
 
 SED_SUBST="$SED_SUBST -e 's|@D_BIN@|${D_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@JAVAC_BIN@|${JAVAC_BIN}|g'"

--- a/src/libfsm/CMakeLists.txt
+++ b/src/libfsm/CMakeLists.txt
@@ -38,10 +38,12 @@ target_include_directories(libfsm
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/aapl>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libfsm>)
 
+# libfsm carries colm's version, not the suite's, matching libcolm and the
+# libtool -release string in Makefile.am.
 set_target_properties(libfsm PROPERTIES
 	OUTPUT_NAME fsm
-	VERSION ${PROJECT_VERSION}
-	SOVERSION ${PROJECT_VERSION_MAJOR})
+	VERSION ${COLM_VERSION_NUMERIC}
+	SOVERSION ${COLM_VERSION_MAJOR})
 
 add_library(ragel::libfsm ALIAS libfsm)
 

--- a/src/libfsm/Makefile.am
+++ b/src/libfsm/Makefile.am
@@ -45,7 +45,7 @@ dist_libfsm_la_SOURCES = \
 	dot.cc asm.cc
 
 if INSTALL_RAGEL
-libfsm_la_LDFLAGS = -release $(VERSION) -no-undefined
+libfsm_la_LDFLAGS = -release ${COLM_VERSION} -no-undefined
 
 if LINKER_NO_UNDEFINED
 libfsm_la_LDFLAGS += -Wl,--no-undefined


### PR DESCRIPTION
Two pre-release build fixes, one commit each.

## libfsm carries colm's version, not the suite's

The suite version became ragel's 7.1.0 when the trees merged, so libfsm — released with `-release $(VERSION)` — would have jumped from `libfsm-0.x.so` to `libfsm-7.1.0.so`, while libcolm deliberately stays on `COLM_VERSION`. Both build systems now version libfsm with colm's number, keeping the two libraries a colm install carries on the same series:

- autotools: `libfsm-0.15.0-pre.1.so` (was `libfsm-7.1.0-pre.1.so`)
- cmake (`-DBUILD_SHARED_LIBS=ON`): `libfsm.so.0.15.0` / `libfsm.so.0`, matching libcolm, with the same explanatory comment.

## asm conftest links with -no-pie

The configure probe deciding whether the asm tests can build linked without `-no-pie`, while the tests themselves pass it (`gentests.sh`). The probe's `movq $.L_works, %rdi` is an absolute relocation — precisely what a PIE link refuses — so on PIE-default gcc the probe failed and the asm suite was silently skipped even on x86-64. The probe now uses the same flag as the tests, and cleans up its binary.

## Verification

- Built via autotools and cmake shared on arm64; library names above confirmed, second `make` idempotent.
- Configure runs cleanly on arm64 with the asm probe correctly answering "no" (x86-64-only source). The positive path — probe answering "yes" and the asm cases running instead of skipping — needs a check on an x86-64 host.