### PR TITLE
Disable the tsreset case until the issue #76 fix lands

### DIFF
--- a/test/ragel.d/tsreset.rl
+++ b/test/ragel.d/tsreset.rl
@@ -1,5 +1,12 @@
 /*
  * @LANG: c++
+ *
+ * @ENABLED: false
+ *
+ * Known-failing marker for issue #76: ragel 7 runs from-state actions on
+ * EOF, so ts is re-set at EOF instead of staying null after the last
+ * token. The fix (branch set-ts-on-first-char) is deferred past 7.1.0.
+ * Re-enable when it lands.
  */
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
`tsreset.rl` was added (841bd4cf, Dec 2021) as a deliberately failing marker for issue #76 — ragel 7 runs from-state actions on EOF, so a scanner's `ts` is re-set at EOF instead of staying null after the last token. The fix on branch `set-ts-on-first-char` is deferred past the 7.1.0 release, so the case's 13 variants were the only failures left in the suite.

Mark it `@ENABLED: false` — the same header `argsinc.rl` and `include1.rl` already use, honored by `gentests.sh` — with a comment explaining the deferral and when to re-enable it.

## Verification

Full `./test/runtests` in the dev image (arm64): **6030 cases, 0 failures, exit 0** — the first fully clean run of the suite. tsreset no longer appears in the run.

One note for the eventual re-enable: the `@ENABLED` check in `gentests.sh` skips a case whenever the header is present with *any* value (`[ -n "$enabled" ] || [ "$enabled" = true ]` — the second test is unreachable), so re-enabling means deleting the header line, not setting it to true.