### PR TITLE
Release colm-suite 2026.08

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,10 @@ endif()
 #
 file(READ "${CMAKE_CURRENT_LIST_DIR}/configure.ac" _configure_ac)
 
-# The suite version is ragel's, being the highest of the components. Colm
-# versions independently and lower, so it carries its own number.
+# The suite is a calendar-versioned distribution, YYYY.MM; each component
+# carries its own version, declared as variables further down.
 #
-# AC_INIT([colm-suite],[7.1.0-pre.1])
+# AC_INIT([colm-suite],[2026.08])
 set(_ac_init_re "AC_INIT\\(\\[?([A-Za-z0-9_.+-]+)\\]?,[ \t]*\\[?([A-Za-z0-9_.+-]+)\\]?")
 if(NOT _configure_ac MATCHES "${_ac_init_re}")
 	message(FATAL_ERROR "could not read AC_INIT from configure.ac")

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ dnl SOFTWARE.
 dnl The suite is a calendar-versioned distribution: YYYY.MM, zero padded,
 dnl with an optional micro for fixups (2026.08, then 2026.08.1) and -pre.N
 dnl for pre-releases. Each component carries its own version, declared below.
-AC_INIT([colm-suite],[2026.08-pre.1])
+AC_INIT([colm-suite],[2026.08])
 PUBDATE="August 2026"
 
 dnl
@@ -31,8 +31,8 @@ dnl Component versions. Every shipped component is versioned independently
 dnl of the suite: colm and ragel continue their own lines, aapl resumes the
 dnl line that ended at 2.14 in 2006, libfsm and cgil start their own.
 dnl
-COLM_VERSION="0.15.0-pre.1"
-COLM_PUBDATE="April 2026"
+COLM_VERSION="0.15.0"
+COLM_PUBDATE="August 2026"
 
 AAPL_VERSION="2.15.0"
 LIBFSM_VERSION="1.0.0"
@@ -489,8 +489,8 @@ AC_SUBST(SED_SUBST)
 dnl
 dnl Ragel build configuration
 dnl
-RAGEL_VERSION="7.1.0-pre.1"
-RAGEL_PUBDATE="April 2026"
+RAGEL_VERSION="7.1.0"
+RAGEL_PUBDATE="August 2026"
 AC_SUBST(RAGEL_VERSION)
 AC_SUBST(RAGEL_PUBDATE)
 

--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -1,4 +1,4 @@
-colm 0.15.0 - Aug 19, 2026
+colm 0.15.0 - Aug 26, 2026
 --------------------------
 	* Colm and ragel are distributed together, in a single colm-suite tarball.
 	  Ragel's front end is written in colm, and earlier ragel 7 releases

--- a/src/aapl/ChangeLog
+++ b/src/aapl/ChangeLog
@@ -1,4 +1,4 @@
-Aapl 2.15.0 - August 19, 2026
+Aapl 2.15.0 - August 26, 2026
 =============================
  -First release since 2.14, twenty years on. Aapl now ships as a component
   of the colm suite rather than on its own, and is versioned independently

--- a/src/cgil/ChangeLog
+++ b/src/cgil/ChangeLog
@@ -1,4 +1,4 @@
-cgil 1.0.0 - Aug 19, 2026
+cgil 1.0.0 - Aug 26, 2026
 -------------------------
 	* First independently versioned release. CGIL is the code generation
 	  intermediate language: the ril grammar plus the per-host-language rlhc

--- a/src/ragel/ChangeLog
+++ b/src/ragel/ChangeLog
@@ -1,4 +1,4 @@
-Ragel 7.1.0 - Aug 19, 2026
+Ragel 7.1.0 - Aug 26, 2026
 ==========================
  -Added Zig as a host language. The ragel-zig program supports all code
   styles.


### PR DESCRIPTION
The release commit for the first calendar-versioned suite release: **colm-suite 2026.08**, containing ragel 7.1.0, colm 0.15.0, libfsm 1.0.0, cgil 1.0.0 and aapl 2.15.0.

- `-pre.1` dropped from AC_INIT, COLM_VERSION and RAGEL_VERSION; all pubdates set to August 2026.
- August 26, 2026 stamped on the colm, ragel, cgil and aapl ChangeLog headings.
- One stale comment in the cmake version-parsing block still described the highest-component naming; reworded.

## Verification

- `colm -v` → `Colm version 0.15.0 August 2026`; `ragel --version` → `... 7.1.0 August 2026`.
- `make dist` → `colm-suite-2026.08.tar.gz`; extracted, configured, built, `make check` + full `test/runtests` in the dev image: 5888 cases, 0 failures, exit 0.

After merge: tag `colm-suite-2026.08`, `ragel-7.1.0`, `colm-0.15.0`, `aapl-2.15.0`, `libfsm-1.0.0`, `cgil-1.0.0`; upload the signed tarball and update the website.