### PR TITLE
rust: accept the multi-character escapes in a char literal

### DIFF
--- a/src/cgil/rlhc-rust.lm
+++ b/src/cgil/rlhc-rust.lm
@@ -27,9 +27,19 @@ namespace rust_out
 
 		token lifetime / "'" id /
 
+		# The string form covers byte and C strings as well; the prefix scans as
+		# an id and the escape loop already accepts backslash-anything, which
+		# takes in \xNN, \u{...} and the backslash-newline continuation. The
+		# char form must spell out the multi-character escapes because it takes
+		# exactly one item before the closing quote.
 		token string /
 				'"' ( [^"\\] | '\\' any ) * '"' |
-				"'" ( [^\\] | '\\' any ) "'"
+				"'" (
+					[^\\] |
+					'\\' 'x' [0-9a-fA-F] [0-9a-fA-F] |
+					'\\' 'u{' [0-9a-fA-F_]+ '}' |
+					'\\' any
+				) "'"
 			/
 
 		ignore

--- a/src/ragel/host-rust/rlparse.lm
+++ b/src/ragel/host-rust/rlparse.lm
@@ -18,8 +18,19 @@ rl block_comment
 rl line_comment
 	/ '//' [^\n]* NL /
 
+# A char literal holds exactly one item, so the multi-character escapes have to
+# be spelled out; backslash-anything alone stops at '\x' and '\u'. This keeps
+# the literal atomic instead of letting its interior scan as separate tokens,
+# and matches what the output grammar in cgil/rlhc-rust.lm accepts.
+rl char_escape
+	/ '\\' (
+		'x' [0-9a-fA-F] [0-9a-fA-F] |
+		'u{' [0-9a-fA-F_]+ '}' |
+		(any | NL)
+	) /
+
 rl char_literal
-	/ "'" ([^\\\n] | '\\' (any | NL)) "'" /
+	/ "'" ([^\\\n] | char_escape) "'" /
 
 rl string_literal
 	/ '"' ([^"\\] | NL | '\\' (any | NL))* '"' /


### PR DESCRIPTION
Part of #184 — the rust half.

A char literal holds exactly one item before the closing quote, so the
multi-character escapes have to be spelled out. `'\\' any` alone stops at the
`x` or the `u`, leaving the output grammar with no transition to take:

```
let e = '\x41';      => failed to parse output: <text2>:14:9: parse error
let n = '\u{7}';     => failed to parse output: <text2>:14:9: parse error
let q = '\'';        => OK
```

Checked against the Rust Reference, this was the only gap in the escape
handling. The string form needs nothing — its escape loop already accepts both,
along with the backslash-newline continuation, and the `b` and `c` prefixes for
byte and C strings scan as an id:

| form | escapes | before | after |
| --- | --- | --- | --- |
| `'c'` char | `\'` `\"` `\n` `\r` `\t` `\\` `\0`, `\xNN`, `\u{H..}` | `\` + one char only | full set |
| `"..."` string | same, plus `\`+newline | ok | ok |
| `b'c'` byte | `\xNN`, no `\u{}` | ok | ok |
| `b"..."` byte string | byte escapes + continuation | ok | ok |
| `c"..."` C string | byte and unicode escapes | ok | ok |
| `r"..."`, `r#"..."#` raw | none | not modelled | not modelled |
| `br"..."`, `cr"..."` raw | none | not modelled | not modelled |

Raw strings stay unmodelled: `r#...#"` takes one to 255 hashes and is not
regular.

The frontend scanner gets the same widening so the two rust scanners agree on
what a char literal is. No input is known to need it there — the frontend copies
host text through, and `'\u{...}'` contributes a balanced pair of braces to the
inline scanner either way — so that half is for consistency.

## Not covered here

The other report in #184, the harfbuzz input, is a different defect: host text is
rejected for any character outside a narrow set, `\` in a multi-line macro being
the usual trigger. That affects ten of the twelve backends and is filed as #236.

## Testing

`test/ragel.d`, 5551 tests, no failures. One flake, `java2_T1`, was a JVM
`hsperfdata` lock warning leaking into stdout under parallel load; it passes in
isolation.
